### PR TITLE
HotFix duplicate entry in json object

### DIFF
--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -3051,7 +3051,6 @@
     "result": "pot_makeshift_copper",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "pot_makeshift_copper",
     "time": "5 m",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "copper_scrap_equivalent", 16, "LIST" ] ] ]


### PR DESCRIPTION
#### Summary
SUMMARY: None
#### Purpose of change
```
Terminated: data/mods//dda/../../json/recipes/recipe_deconstruction.json: line 3054:14: duplicate entry in json object

    "type": "uncraft",
    "activity_level": "MODERATE_EXERCISE",
    "result":
             ^
              "pot_makeshift_copper",
    "time": "5 m",
    "qualities": [ { "id": "HAMMER", "level": 1 } ],

Make sure that you're in the correct working directory and your data isn't corrupted.
make[1]: *** [check] Error 1
```
#### Describe the solution
Remove duplicate entry `"result": "pot_makeshift_copper"` in `recipe_deconstruction.json`.
#### Testing
```
===============================================================================
All tests passed (2668229 assertions in 543 test cases)
```